### PR TITLE
docs: cloud config git default label 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,7 +4,9 @@ spring:
       on-profile: dev
   cloud:
     config:
-      label: develop
+      server:
+        git:
+          default-label: develop
   rabbitmq:
     host: rabbitmq-service
     port: 5672

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,9 @@ spring:
       on-profile: local
   cloud:
     config:
-      label: develop
+      server:
+        git:
+          default-label: develop
   rabbitmq:
     host: 127.0.0.1
     port: 5672

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,7 +4,9 @@ spring:
       on-profile: prod
   cloud:
     config:
-      label: main
+      server:
+        git:
+          default-label: main
   rabbitmq:
     host: rabbitmq-service
     port: 5672


### PR DESCRIPTION
- cloud.config.server.git.default-lablel 로 브랜치 설정해줘야 해당 브랜치 파일 읽을 수 있음

## pull request 설명

### 변경 사항

- [x] fix bug
- [ ] add comment
- [ ] add new feature
- [x] update documents
- [ ] Improvement(refactoring and improving code)
- [ ] etc
